### PR TITLE
Fix scrape example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ scrape:
               labels:
                 - name: "queue"
                   value: "$Queue"  # Use '$' to access attributes from the filtered event
-      until: "ContactStatusDetailComplete"
+      until: "QueueStatusComplete"
 ```
 
 ## Example configuration


### PR DESCRIPTION
Fixed the scrape example specifying an incorrect `until`-event in the README.