### PR TITLE
Update workflow trigger

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,6 @@
 name: flake8 Lint
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   flake8-lint:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: test
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   unit-tests:


### PR DESCRIPTION
Updated workflow `lint` and `test` to only run on the `pull_request` trigger. This is done to prevent the workflows from starting twice when puhsing to a branch with a pull request.